### PR TITLE
Write CSV to stdout, for consistency

### DIFF
--- a/getinfo.yml
+++ b/getinfo.yml
@@ -11,5 +11,5 @@
       local_action: copy content="{{ retval.repos|to_json }}" dest=./results.txt
 
     - name: Provide CSV
-      local_action: shell ./json2csv.py < results.txt
+      local_action: shell ./json2csv.py < results.txt > results.csv
 

--- a/json2csv.py
+++ b/json2csv.py
@@ -4,7 +4,7 @@ import csv
 import json
 import sys
 
-w = csv.writer(open('results.csv', 'w'))
+w = csv.writer(sys.stdout)
 
 s = sys.stdin.read()
 repos = json.loads(s)


### PR DESCRIPTION
Input is read from stdin, so for consistency, output should go to stdout,
instead of hardcoding the CSV file name in the script.
